### PR TITLE
Fix icon loading NPE on Apple Silicon Macs

### DIFF
--- a/common/src/main/java/bisq/common/util/OsUtils.java
+++ b/common/src/main/java/bisq/common/util/OsUtils.java
@@ -55,7 +55,7 @@ public class OsUtils {
     }
 
     public static boolean isMac() {
-        return getOSName().contains("mac") || getOSName().contains("darwin");
+        return getOSName().toLowerCase().contains("mac") || getOSName().contains("darwin");
     }
 
     public static boolean isLinux() {

--- a/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
+++ b/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
@@ -35,7 +35,7 @@ public class ImageUtil {
 
     // Does not resolve the @2x automatically
     public static Image getImageByPath(String path) {
-        try (InputStream resourceAsStream = ImageView.class.getClassLoader().getResourceAsStream(path)) {
+        try (InputStream resourceAsStream = ImageUtil.class.getClassLoader().getResourceAsStream(path)) {
             if (resourceAsStream == null) {
                 return null;
             }
@@ -48,7 +48,7 @@ public class ImageUtil {
     }
 
     public static Image getImageByPath(String path, int width, int height) {
-        try (InputStream resourceAsStream = ImageView.class.getClassLoader().getResourceAsStream(path)) {
+        try (InputStream resourceAsStream = ImageUtil.class.getClassLoader().getResourceAsStream(path)) {
             if (resourceAsStream == null) {
                 return null;
             }


### PR DESCRIPTION
Prior to this change, a `NullPointerException` would occur when attempting to load resources such as `images/window_icon@2x.png` on an Apple Silicon Mac building and running Bisq atop Azul JDK 17.

The source of the bug is the inadvertent use of a javafx class's classloader to do the resource loading. Apparently this is not a problem on other platforms/architectures running against Oracle or OpenJDK JREs, but perhaps because of the way Azul packages javafx classes into their JDK, a segregated classloader ends up being used that does not have access to these resources.

In any case, the use of the `ImageView` javafx class was, again, just an oversight / typo. The class that should have been used, and now is used, is Bisq's own ImageUtil, i.e. the class that encloses the static methods in question. With this fix in place, the icon resources can be loaded as streams as expected.

Another fix that was necessary along the way was relaxing case sensitivity on determining whether the host is a Mac. Previously, the case-sensitive string "mac" was evaluated, but this missed the actual `System.getProperty("os.name")` value of "Mac OS X" that is returned by at least some Macs, or again, perhaps those running Azul's custom JDK.